### PR TITLE
Update pr.go to check if .Type is empty to avoid trying to create an empty label

### DIFF
--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -126,8 +126,10 @@ func TemplatePR(
 			if !ok {
 				label = typeStr
 			}
-
-			pr.Labels = append(pr.Labels, label)
+			// Ensure we don't add an empty label
+			if label != "" {
+				pr.Labels = append(pr.Labels, label)
+			}	
 		}
 	}
 


### PR DESCRIPTION
## Description

When creating a branch pattern where `{{.Type}}` is optional `gh prx` fails to create label with error:
```
⨯ Command failed                                     error=Failed to create labels: Failed to create label '': failed to run gh: HTTP 422: Validation Failed (https://api.github.com/repos/customerOrg/repoTest/labels)
```

```
branch:
   template: "{{.Type}}/{{with .Issue}}{{.}}-{{end}}{{.Description}}" # Branch name template
   pattern: "({{.Type}}|{{.Prefix}})\\/({{.Issue}}-)?{{.Description}}" # Branch name pattern
   variable_patterns: # A map of patterns to match for each template variable
      Type: "fix|feat|chore|docs|refactor|test|style|build|ci|perf|revert"
      # Branch name prefix like dougnukem/JIRAPROJ-XYZ-description-stuff
      Prefix: "[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*"
      Issue: "([a-zA-Z]+\\-)*[0-9]+"
      Author: "[a-zA-Z0-9]+"
      Description: ".*"
   token_separators: ["-", "_"] # Characters used to separate branch name into a human-readable string
   max_length: 60 # Max characters to allow for branch length without prompting for changing it
```
